### PR TITLE
UseHealthChecks instead of UserHealthChecks

### DIFF
--- a/docs/standard/microservices-architecture/implement-resilient-applications/monitor-app-health.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/monitor-app-health.md
@@ -100,7 +100,7 @@ services.AddHealthChecks(checks =>
 });
 ```
 
-For a service or web application to expose the health check endpoint, it has to enable the UserHealthChecks(\[*url\_for\_health\_checks*\]) extension method. This method goes at the WebHostBuilder level in the main method of the Program class of your ASP.NET Core service or web application, right after UseKestrel as shown in the code below.
+For a service or web application to expose the health check endpoint, it has to enable the UseHealthChecks(\[*url\_for\_health\_checks*\]) extension method. This method goes at the WebHostBuilder level in the main method of the Program class of your ASP.NET Core service or web application, right after UseKestrel as shown in the code below.
 
 ```csharp
 namespace Microsoft.eShopOnContainers.WebMVC


### PR DESCRIPTION
Given that there are [not references](https://github.com/dotnet-architecture/HealthChecks/search?utf8=%E2%9C%93&q=UserHealthChecks&) to UserHealthChecks in the HealthChecks repository, I believe this is a typo.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
